### PR TITLE
Handle invalid response body

### DIFF
--- a/pkg/v1/client.go
+++ b/pkg/v1/client.go
@@ -212,7 +212,8 @@ func (result *ResponseResult) extractErr() error {
 		err = json.Unmarshal(body, &result.ErrGeneric)
 	}
 	if err != nil {
-		return err
+		result.Err = fmt.Errorf("domains-go: got invalid response from the server")
+		return nil
 	}
 
 	result.Err = fmt.Errorf("domains-go: got the %d status code from the server: %s",


### PR DESCRIPTION
Do not return error in extractErr method, set ResponseResult.Err
instead to be able to handle it gracefully on the client's side (do retries for example).

