### PR TITLE
Add support for ALIAS, CAA and SSHFP records

### DIFF
--- a/pkg/v1/client.go
+++ b/pkg/v1/client.go
@@ -16,7 +16,7 @@ const (
 	appName = "domains-go"
 
 	// appVersion is a version of the application.
-	appVersion = "0.3.0"
+	appVersion = "0.4.0"
 
 	// userAgent contains a basic user agent that will be used in queries.
 	userAgent = appName + "/" + appVersion

--- a/pkg/v1/record/doc.go
+++ b/pkg/v1/record/doc.go
@@ -64,5 +64,39 @@ Example of domain record updating
     log.Fatal(err)
   }
   fmt.Printf("%+v\n", updatedRecord)
+
+Examples of option struct for different types of records
+
+ALIAS
+
+  createOpts := &record.CreateOpts{
+    Name:     "sub.example.com",
+    Type:     record.TypeALIAS,
+    TTL:      60,
+    Content:  "example.com",
+  }
+  
+CAA
+
+  createOpts := &record.CreateOpts{
+    Name:     "example.com",
+    Type:     record.TypeCAA,
+    TTL:      60,
+    Tag:  "issue",
+    Flag: 32,
+    Value: "letsencrypt.org",
+  }
+
+SSHFP
+
+  createOpts := &record.CreateOpts{
+    Name:     "example.com",
+    Type:     record.TypeSSHFP,
+    TTL:      60,
+    Algrotihm:  1,
+    FingerprintType: 2,
+    Fingerprint: "RtvgDtzHTaRB5d2Yy5c1",
+  }
+
 */
 package record

--- a/pkg/v1/record/requests_opts.go
+++ b/pkg/v1/record/requests_opts.go
@@ -36,6 +36,30 @@ type CreateOpts struct {
 	// Target represents the canonical hostname of the machine providing the service.
 	// For SRV records only.
 	Target string `json:"target,omitempty"`
+
+	// Tag rrepresents the identifier of the property represented by the record.
+	// For CAA records only.
+	Tag string `json:"tag,omitempty"`
+
+	// Flag represents the critical flag, that has a specific meaning per RFC.
+	// For CAA records only.
+	Flag *int `json:"flag,omitempty"`
+
+	// The value associated with the tag.
+	// For CAA records only.
+	Value string `json:"value,omitempty"`
+
+	// Algorithm.
+	// For SSHFP records only.
+	Algorithm *int `json:"algorithm,omitempty"`
+
+	// Algorithm used to hash the public key
+	// For SSHFP records only.
+	FingerprintType *int `json:"fingerprint_type,omitempty"`
+
+	// Hexadecimal representation of the hash result, as text.
+	// For SSHFP records only.
+	Fingerprint string `json:"fingerprint,omitempty"`
 }
 
 // UpdateOpts represents requests options to update a domain record.
@@ -74,4 +98,28 @@ type UpdateOpts struct {
 	// Target represents the canonical hostname of the machine providing the service.
 	// For SRV records only.
 	Target string `json:"target,omitempty"`
+
+	// Tag rrepresents the identifier of the property represented by the record.
+	// For CAA records only.
+	Tag string `json:"tag,omitempty"`
+
+	// Flag represents the critical flag, that has a specific meaning per RFC.
+	// For CAA records only.
+	Flag *int `json:"flag,omitempty"`
+
+	// The value associated with the tag.
+	// For CAA records only.
+	Value string `json:"value,omitempty"`
+
+	// Algorithm.
+	// For SSHFP records only.
+	Algorithm *int `json:"algorithm,omitempty"`
+
+	// Algorithm used to hash the public key
+	// For SSHFP records only.
+	FingerprintType *int `json:"fingerprint_type,omitempty"`
+
+	// Hexadecimal representation of the hash result, as text.
+	// For SSHFP records only.
+	Fingerprint string `json:"fingerprint,omitempty"`
 }

--- a/pkg/v1/record/requests_opts.go
+++ b/pkg/v1/record/requests_opts.go
@@ -37,7 +37,7 @@ type CreateOpts struct {
 	// For SRV records only.
 	Target string `json:"target,omitempty"`
 
-	// Tag rrepresents the identifier of the property represented by the record.
+	// Tag represents the identifier of the property represented by the record.
 	// For CAA records only.
 	Tag string `json:"tag,omitempty"`
 
@@ -99,7 +99,7 @@ type UpdateOpts struct {
 	// For SRV records only.
 	Target string `json:"target,omitempty"`
 
-	// Tag rrepresents the identifier of the property represented by the record.
+	// Tag represents the identifier of the property represented by the record.
 	// For CAA records only.
 	Tag string `json:"tag,omitempty"`
 

--- a/pkg/v1/record/schemas.go
+++ b/pkg/v1/record/schemas.go
@@ -64,7 +64,7 @@ type View struct {
 	// For SRV records only.
 	Target string `json:"target,omitempty"`
 
-	// Tag rrepresents the identifier of the property represented by the record.
+	// Tag represents the identifier of the property represented by the record.
 	// For CAA records only.
 	Tag string `json:"tag,omitempty"`
 

--- a/pkg/v1/record/schemas.go
+++ b/pkg/v1/record/schemas.go
@@ -14,6 +14,9 @@ const (
 	TypeSOA     Type = "SOA"
 	TypeMX      Type = "MX"
 	TypeSRV     Type = "SRV"
+	TypeCAA     Type = "CAA"
+	TypeSSHFP   Type = "SSHFP"
+	TypeALIAS   Type = "ALIAS"
 	TypeUnknown Type = "UNKNOWN"
 )
 
@@ -60,6 +63,30 @@ type View struct {
 	// Target represents the canonical hostname of the machine providing the service.
 	// For SRV records only.
 	Target string `json:"target,omitempty"`
+
+	// Tag rrepresents the identifier of the property represented by the record.
+	// For CAA records only.
+	Tag string `json:"tag,omitempty"`
+
+	// Flag represents the critical flag, that has a specific meaning per RFC.
+	// For CAA records only.
+	Flag *int `json:"flag,omitempty"`
+
+	// The value associated with the tag.
+	// For CAA records only.
+	Value string `json:"value,omitempty"`
+
+	// Algorithm.
+	// For SSHFP records only.
+	Algorithm *int `json:"algorithm,omitempty"`
+
+	// Algorithm used to hash the public key
+	// For SSHFP records only.
+	FingerprintType *int `json:"fingerprint_type,omitempty"`
+
+	// Hexadecimal representation of the hash result, as text.
+	// For SSHFP records only.
+	Fingerprint string `json:"fingerprint,omitempty"`
 }
 
 func (result *View) UnmarshalJSON(b []byte) error {
@@ -93,6 +120,12 @@ func (result *View) UnmarshalJSON(b []byte) error {
 		result.Type = TypeSRV
 	case TypeSOA:
 		result.Type = TypeSOA
+	case TypeCAA:
+		result.Type = TypeCAA
+	case TypeALIAS:
+		result.Type = TypeALIAS
+	case TypeSSHFP:
+		result.Type = TypeSSHFP
 	default:
 		result.Type = TypeUnknown
 	}

--- a/pkg/v1/record/testing/fixtures.go
+++ b/pkg/v1/record/testing/fixtures.go
@@ -107,6 +107,31 @@ const testListResponseRaw = `
       "port" : 5222,
       "type" : "SRV",
       "priority" : 20
+   },
+   {
+      "name" : "caa.testdomain.xyz",
+      "ttl" : 86400,
+      "id" : 4892462,
+      "type" : "CAA",
+      "tag" : "issue",
+      "flag" : 1,
+      "value" : "letsencrypt.com"
+   },
+   {
+      "name" : "sshfp.testdomain.xyz",
+      "ttl" : 86400,
+      "id" : 4892472,
+      "type" : "SSHFP",
+      "algorithm" : 1,
+      "fingerprint_type" : 1,
+      "fingerprint" : "001a2B3CFF"
+   },
+   {
+      "name" : "testdomain.zyx",
+      "ttl" : 86400,
+      "id" : 4892482,
+      "type" : "ALIAS",
+      "content" : "testdomain.xyz"
    }
 ]
 `
@@ -180,6 +205,31 @@ var expectedListResponse = []*record.View{
 		Weight:   testutils.IntPtr(0),
 		Port:     testutils.IntPtr(5222),
 		Target:   "xmpp.example.com",
+		TTL:      86400,
+	},
+   {
+		ID:       4892462,
+		Name:     "caa.testdomain.xyz",
+		Type:     record.TypeCAA,
+		Tag:      "issue",
+		Flag:     testutils.IntPtr(1),
+		Value:    "letsencrypt.com",
+		TTL:      86400,
+	},
+   {
+		ID:                  4892472,
+		Name:                "sshfp.testdomain.xyz",
+		Type:                record.TypeSSHFP,
+		Algorithm:           testutils.IntPtr(1),
+		FingerprintType:     testutils.IntPtr(1),
+		Fingerprint:         "001a2B3CFF",
+		TTL:                 86400,
+	},
+   {
+		ID:       4892482,
+		Name:     "testdomain.zyx",
+		Type:     record.TypeALIAS,
+		Content:  "testdomain.xyz",
 		TTL:      86400,
 	},
 }


### PR DESCRIPTION
Domains api now supports CAA, ALIAS and SSHFP records
unittests - extended with new schemas and passed
linter - too broken too fix within this PR